### PR TITLE
Fix fast line numbering bug

### DIFF
--- a/emacs.d.symlink/init.el
+++ b/emacs.d.symlink/init.el
@@ -23,13 +23,14 @@
 See URL `http://emacs.stackexchange.com/a/3822' for limitations
 and URL `https://github.com/basil-conto/dotfiles/blob/master/\
 .emacs.d/init.el' for inspiration."
-  (let ((line-number-display-limit-width most-positive-fixnum)
+  (let ((line-number-display-limit-width most-positive-fixnum) ; Any line width
+        (line-number-display-limit nil)                        ; Any buffer size
         (pmax (point-max)))
     (save-excursion
       (goto-char pmax)
-      (- (string-to-number (format-mode-line "%l"))
-         ;; Adjust for trailing newline
-         (if (= pmax (line-beginning-position)) 1 0)))))
+      ;; Adjust for trailing newline
+      (funcall (if (= pmax (line-beginning-position)) #'1- #'identity)
+               (string-to-number (format-mode-line "%l"))))))
 
 
 ;;; ----------------

--- a/emacs.d.symlink/init.el
+++ b/emacs.d.symlink/init.el
@@ -232,11 +232,11 @@ and URL `https://github.com/basil-conto/dotfiles/blob/master/\
 
 (use-package whitespace
   :init
-  (global-whitespace-mode 1)
+  (global-whitespace-mode)
   :config
   (setq-default whitespace-style '(face
-								   trailing  ; trailing blanks
-								   empty)))  ; empty start/end of buffer
+                                   trailing  ; trailing blanks
+                                   empty)))  ; empty start/end of buffer
 
 (use-package windmove
   :init


### PR DESCRIPTION
Just found these two commits lying around from back when I had implemented the fast line count function.

I had originally forgotten to set `line-number-display-limit` to `nil`, which allows the line number to be calculated irrespective of buffer size.

The other changes in this PR are purely aesthetic, so feel free to ignore them.